### PR TITLE
Corrected node requirement

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -22,7 +22,7 @@ Further configuration options are available in the `intelephense` section of set
 ### Other Editors
 
 #### Requirements
-[Node.js 12+](https://nodejs.org)
+[Node.js 18+](https://nodejs.org)
 
 #### Server Installation
 ```


### PR DESCRIPTION
Using a version underneath 18 gives an `unsupported engine` warning nowadays